### PR TITLE
Add raises-exception tag to expected error cell

### DIFF
--- a/notebooks/01-intro.ipynb
+++ b/notebooks/01-intro.ipynb
@@ -292,7 +292,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "e67c8a76-b375-40ec-9546-d78a0afe858e",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "raises-exception"
+    ]
+   },
    "outputs": [],
    "source": [
     "chart.selection # <- oh no, error!!!"


### PR DESCRIPTION
Trivial change, feel free to ignore.

Adds the `raises-exception` tag to the cell that is expected to fail in the first notebook so that you can run the entire notebook with the Run All command.